### PR TITLE
Added support for path structs

### DIFF
--- a/internal/ast/parser.go
+++ b/internal/ast/parser.go
@@ -35,11 +35,11 @@ func ParseSchema(r io.Reader) (*AST, error) {
 
 type lexerDefinition struct{}
 
-func (d *lexerDefinition) Lex(r io.Reader) lexer.Lexer {
+func (d *lexerDefinition) Lex(r io.Reader) (lexer.Lexer, error) {
 	s := &scanner.Scanner{}
 	l := lexer.LexWithScanner(r, s)
 	s.Mode = s.Mode &^ scanner.SkipComments
-	return l
+	return l, nil
 }
 
 func (d *lexerDefinition) Symbols() map[string]rune {

--- a/langs/go/go.go
+++ b/langs/go/go.go
@@ -131,13 +131,14 @@ func (m *GoModeler) writeModel(model *firemodel.SchemaModel, sourceCoder firemod
 		f.Commentf("%s is a function that turns a firestore path into a PathStruct of %s", pathStructFunctionName, model.Name)
 		f.
 			Func().
-			Id(pathStructFunctionName).Params(jen.Id("path").String()).Id(pathStructName).BlockFunc(func(g *jen.Group) {
+			Id(pathStructFunctionName).Params(jen.Id("path").String()).Id("*" + pathStructName).BlockFunc(func(g *jen.Group) {
 			g.Id("parsed").Op(":=").Id(fmt.Sprint(model.Name, "RegexPath")).Dot("FindStringSubmatch").Call(jen.Id("path"))
 			g.Id("result").Op(":=").Op("&").Id(pathStructName).ValuesFunc(func(g *jen.Group) {
 				for i, arg := range args {
 					g.Id(strcase.ToCamel(arg)).Op(":").Id("parsed").Index(jen.Lit(i))
 				}
 			})
+			g.Return(jen.Id("result"))
 		})
 
 		f.Commentf("%s is a function that turns a PathStruct of %s into a firestore path", pathStructReverseFunctionName, model.Name)

--- a/langs/go/go.go
+++ b/langs/go/go.go
@@ -150,6 +150,14 @@ func (m *GoModeler) writeModel(model *firemodel.SchemaModel, sourceCoder firemod
 			})
 			g.Return(jen.Id("built"))
 		})
+
+		wrapperName := fmt.Sprint(model.Name, "Wrapper")
+		f.Commentf("%s is a struct wrapper that contains a reference to the firemodel instance and the path", wrapperName)
+		f.Type().Id(wrapperName).StructFunc(func(g *jen.Group) {
+			g.Id(model.Name).Id("*" + model.Name)
+			g.Id("Path").Id(pathStructName)
+			g.Id("PathStr").String()
+		})
 	}
 
 	w, err := sourceCoder.NewFile(fmt.Sprint(strcase.ToSnake(model.Name), fileExtension))

--- a/langs/go/go.go
+++ b/langs/go/go.go
@@ -135,7 +135,7 @@ func (m *GoModeler) writeModel(model *firemodel.SchemaModel, sourceCoder firemod
 			g.Id("parsed").Op(":=").Id(fmt.Sprint(model.Name, "RegexPath")).Dot("FindStringSubmatch").Call(jen.Id("path"))
 			g.Id("result").Op(":=").Op("&").Id(pathStructName).ValuesFunc(func(g *jen.Group) {
 				for i, arg := range args {
-					g.Id(strcase.ToCamel(arg)).Op(":").Id("parsed").Index(jen.Lit(i))
+					g.Id(strcase.ToCamel(arg)).Op(":").Id("parsed").Index(jen.Lit(i + 1))
 				}
 			})
 			g.Return(jen.Id("result"))

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
@@ -78,9 +78,10 @@ type TestModelPathStruct struct {
 }
 
 // TestModelPathToStruct is a function that turns a firestore path into a PathStruct of TestModel
-func TestModelPathToStruct(path string) TestModelPathStruct {
+func TestModelPathToStruct(path string) *TestModelPathStruct {
 	parsed := TestModelRegexPath.FindStringSubmatch(path)
 	result := &TestModelPathStruct{UserId: parsed[0], TestModelId: parsed[1]}
+	return result
 }
 
 // TestModelStructToPath is a function that turns a PathStruct of TestModel into a firestore path

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
@@ -70,3 +70,21 @@ var TestModelRegexPath = regexp.MustCompile("^users/([a-zA-Z0-9]+)/test_models/(
 
 // TestModelRegexNamedPath is a named regex that can be use to filter out firestore events of TestModel
 var TestModelRegexNamedPath = regexp.MustCompile("^users/(?P<user_id>[a-zA-Z0-9]+)/test_models/(?P<test_model_id>[a-zA-Z0-9]+)$")
+
+// TestModelPathStruct is a struct that contains parts of a path of TestModel
+type TestModelPathStruct struct {
+	UserId      string
+	TestModelId string
+}
+
+// TestModelPathToStruct is a function that turns a firestore path into a PathStruct of TestModel
+func TestModelPathToStruct(path string) TestModelPathStruct {
+	parsed := TestModelRegexPath.FindStringSubmatch(path)
+	result := &TestModelPathStruct{UserId: parsed[0], TestModelId: parsed[1]}
+}
+
+// TestModelStructToPath is a function that turns a PathStruct of TestModel into a firestore path
+func TestModelStructToPath(path TestModelPathStruct) string {
+	built := fmt.Sprintf("users/%s/test_models/%s", path.UserId, path.TestModelId)
+	return built
+}

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
@@ -88,3 +88,10 @@ func TestModelStructToPath(path TestModelPathStruct) string {
 	built := fmt.Sprintf("users/%s/test_models/%s", path.UserId, path.TestModelId)
 	return built
 }
+
+// TestModelWrapper is a struct wrapper that contains a reference to the firemodel instance and the path
+type TestModelWrapper struct {
+	TestModel *TestModel
+	Path      TestModelPathStruct
+	PathStr   string
+}

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
@@ -80,7 +80,7 @@ type TestModelPathStruct struct {
 // TestModelPathToStruct is a function that turns a firestore path into a PathStruct of TestModel
 func TestModelPathToStruct(path string) *TestModelPathStruct {
 	parsed := TestModelRegexPath.FindStringSubmatch(path)
-	result := &TestModelPathStruct{UserId: parsed[0], TestModelId: parsed[1]}
+	result := &TestModelPathStruct{UserId: parsed[1], TestModelId: parsed[2]}
 	return result
 }
 

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
@@ -46,3 +46,10 @@ func TestTimestampsStructToPath(path TestTimestampsPathStruct) string {
 	built := fmt.Sprintf("timestamps/%s", path.TestTimestampsId)
 	return built
 }
+
+// TestTimestampsWrapper is a struct wrapper that contains a reference to the firemodel instance and the path
+type TestTimestampsWrapper struct {
+	TestTimestamps *TestTimestamps
+	Path           TestTimestampsPathStruct
+	PathStr        string
+}

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
@@ -38,7 +38,7 @@ type TestTimestampsPathStruct struct {
 // TestTimestampsPathToStruct is a function that turns a firestore path into a PathStruct of TestTimestamps
 func TestTimestampsPathToStruct(path string) *TestTimestampsPathStruct {
 	parsed := TestTimestampsRegexPath.FindStringSubmatch(path)
-	result := &TestTimestampsPathStruct{TestTimestampsId: parsed[0]}
+	result := &TestTimestampsPathStruct{TestTimestampsId: parsed[1]}
 	return result
 }
 

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
@@ -36,9 +36,10 @@ type TestTimestampsPathStruct struct {
 }
 
 // TestTimestampsPathToStruct is a function that turns a firestore path into a PathStruct of TestTimestamps
-func TestTimestampsPathToStruct(path string) TestTimestampsPathStruct {
+func TestTimestampsPathToStruct(path string) *TestTimestampsPathStruct {
 	parsed := TestTimestampsRegexPath.FindStringSubmatch(path)
 	result := &TestTimestampsPathStruct{TestTimestampsId: parsed[0]}
+	return result
 }
 
 // TestTimestampsStructToPath is a function that turns a PathStruct of TestTimestamps into a firestore path

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
@@ -29,3 +29,20 @@ var TestTimestampsRegexPath = regexp.MustCompile("^timestamps/([a-zA-Z0-9]+)$")
 
 // TestTimestampsRegexNamedPath is a named regex that can be use to filter out firestore events of TestTimestamps
 var TestTimestampsRegexNamedPath = regexp.MustCompile("^timestamps/(?P<test_timestamps_id>[a-zA-Z0-9]+)$")
+
+// TestTimestampsPathStruct is a struct that contains parts of a path of TestTimestamps
+type TestTimestampsPathStruct struct {
+	TestTimestampsId string
+}
+
+// TestTimestampsPathToStruct is a function that turns a firestore path into a PathStruct of TestTimestamps
+func TestTimestampsPathToStruct(path string) TestTimestampsPathStruct {
+	parsed := TestTimestampsRegexPath.FindStringSubmatch(path)
+	result := &TestTimestampsPathStruct{TestTimestampsId: parsed[0]}
+}
+
+// TestTimestampsStructToPath is a function that turns a PathStruct of TestTimestamps into a firestore path
+func TestTimestampsStructToPath(path TestTimestampsPathStruct) string {
+	built := fmt.Sprintf("timestamps/%s", path.TestTimestampsId)
+	return built
+}


### PR DESCRIPTION
Brings in helper functions that can create structs that contain the path pieces.

Brings in a wrapper that can be used to pass your firemodel objects through your go code that contain the path and the object.